### PR TITLE
Fix boolean value and upgrade bs-platform dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/arnarthor/bs-node-fetch#readme",
   "devDependencies": {
-    "bs-platform": "^1.9.0"
+    "bs-platform": "^4.0.0"
   },
   "dependencies": {
     "node-fetch": "^1.7.2"

--- a/src/bs_node_fetch.ml
+++ b/src/bs_node_fetch.ml
@@ -283,7 +283,7 @@ module RequestInit = struct
     ?cache:string ->
     ?redirect:string ->
     ?integrity:string ->
-    ?keepalive:Js.boolean ->
+    ?keepalive:bool ->
     unit -> requestInit = "" [@@bs.obj]
   let make
     ?method_:(method_: requestMethod option) 
@@ -308,7 +308,7 @@ module RequestInit = struct
         ?cache: (map encodeRequestCache cache)
         ?redirect: (map encodeRequestRedirect redirect)
         ~integrity
-        ?keepalive: (map Js.Boolean.to_js_boolean keepalive)
+        ?keepalive
 end
 
 module Request = struct


### PR DESCRIPTION
Reason/Bucklescript boolean values are now compiled to JS `true` and `false` so we don't need to used `Js.to_bool` and `Js.Boolean.to_js_boolean` anymore.

We were getting compile error on the current project otherwise.

https://reasonml.github.io/docs/en/boolean.html#usage

