### PR TITLE
Update node-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "bs-platform": "^1.9.0"
   },
   "dependencies": {
-    "node-fetch": "^1.7.2"
+    "node-fetch": "^2.1.2"
   }
 }


### PR DESCRIPTION
Node-fetch v2 contains some new (critical) features for us, such as the POST request body can be JSON etc.

Honestly, I didn't check all the details about API changes between v1 and v2 version but it works 🤷‍♂️ 